### PR TITLE
Pull session duration options from config

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ elements that need to be in place first:
     - **event_name:** Display name for the event.
     - **event_year:** Display year for the event.
     - **event_dates:** List of event dates in YYYY-MM-DD format.
+    - **session_durations:** Array of supported talk lengths (in minutes)
 
     ```
     "config": {
@@ -108,6 +109,7 @@ elements that need to be in place first:
       "event_name": "360|Conferences",
       "event_year": "2018",
       "event_dates": ["2018-01-01", "2018-01-02"]
+      "session_durations": [45, 20]
     }
     ```
 

--- a/public/admin/schedule.tmpl.html
+++ b/public/admin/schedule.tmpl.html
@@ -16,6 +16,7 @@
 
       <div class="md-dialog-content">
         <h3>{{ entry.title }}</h3>
+        <p>{{entry.duration}} minutes</p>
         <div layout="row" layout-align="center center">
           <!-- Speaker Chips -->
           <div ng-repeat="speaker in session.speakers">

--- a/public/entry.tmpl.html
+++ b/public/entry.tmpl.html
@@ -15,7 +15,11 @@
         </md-input-container>
         <md-input-container class="md-block" flex-gt-sm>
           <label>Duration (minutes)</label>
-          <input required name="entryDuration" ng-model="entry.duration" />
+          <md-select required name="entryDuration" ng-model="entry.duration">
+            <md-option ng-repeat="option in config.session_durations" ng-value="option">
+              {{option}} minutes
+            </md-option>
+          </md-select>
         </md-input-container>
         <p>
           Enter an abstract description of your talk. This will be visible to

--- a/public/js/admin-app.js
+++ b/public/js/admin-app.js
@@ -417,6 +417,7 @@ app.controller("SubmissionCtrl", function($scope, $firebaseObject, $firebaseArra
   }
 
   function ShowEntryDialog(evt, submissionItem, profileItem) {
+    var submission = submissionItem || {};
     var scores = $scope.feedback.scores || {};
     $mdDialog.show({
       controller: DialogController,
@@ -426,9 +427,9 @@ app.controller("SubmissionCtrl", function($scope, $firebaseObject, $firebaseArra
       clickOutsideToClose:true,
       fullscreen: true,
       locals: {
-        entry: submissionItem,
+        entry: submission,
         speaker: profileItem,
-        feedback: scores[submissionItem.$id],
+        feedback: scores[submission.$id],
         profiles: $scope.profiles
       }
     })

--- a/public/js/speaker-app.js
+++ b/public/js/speaker-app.js
@@ -179,7 +179,7 @@ app.controller("SubmissionCtrl", function($scope, $firebaseAuth, $mdDialog, $mdT
     if($scope.speakerForm.$valid && $scope.speaker.agree_terms) {
       // Simple check that the form was filled out
       // Note: Doesn't actually check if profile saved.
-      var entry = {duration: 40};
+      var entry = {};
       ShowEntryDialog(evt, entry);
     } else {
       // Show error toast
@@ -214,7 +214,7 @@ app.controller("SubmissionCtrl", function($scope, $firebaseAuth, $mdDialog, $mdT
     var entry = {
       id: item.$id,
       title: item.title,
-      duration: item.duration || 40,
+      duration: item.duration,
       abstract: item.abstract,
       notes: item.notes
     };
@@ -251,7 +251,8 @@ app.controller("SubmissionCtrl", function($scope, $firebaseAuth, $mdDialog, $mdT
       clickOutsideToClose:true,
       fullscreen: true,
       locals: {
-        entry: submissionItem
+        entry: submissionItem,
+        config: $scope.config
       }
     })
     .then(function(entry) {
@@ -262,8 +263,9 @@ app.controller("SubmissionCtrl", function($scope, $firebaseAuth, $mdDialog, $mdT
   }
 
   // Handler for entry dialog events
-  function DialogController($scope, $mdDialog, entry) {
+  function DialogController($scope, $mdDialog, entry, config) {
     $scope.entry = entry;
+    $scope.config = config;
     $scope.hide = function() {
       $mdDialog.hide();
     };
@@ -304,7 +306,7 @@ app.controller("SubmissionCtrl", function($scope, $firebaseAuth, $mdDialog, $mdT
   }
 
   $scope.shouldShowFeedback = function(item) {
-    if ($scope.feedback.scores[item.$id]) {
+    if ($scope.feedback.scores && $scope.feedback.scores[item.$id]) {
       return $scope.config.show_feedback;
     } else {
       return false;


### PR DESCRIPTION
Update options for session length to pull from the config node, remove free entry text from user-side submission dialog. In a future change (probably after CFP), I would like the schedule dialog to auto-set the end time based on the talk duration.