### PR TITLE
Shuffle reviewer submissions

### DIFF
--- a/public/js/reviewer-app.js
+++ b/public/js/reviewer-app.js
@@ -66,6 +66,9 @@ app.controller("ReviewCtrl", function($scope, $firebaseAuth, SubmissionList) {
 
     // set up data binding
     $scope.submissions = SubmissionList();
+    $scope.submissions.$loaded().then(function() {
+      shuffle($scope.submissions, firebaseUser.uid);
+    });
   });
 
   // Logic to hide talks from reviewers
@@ -88,3 +91,16 @@ app.controller("ReviewCtrl", function($scope, $firebaseAuth, SubmissionList) {
     return true;
   };
 });
+
+// Taken from https://bost.ocks.org/mike/shuffle/compare.html
+function shuffle(array, seed) {
+  Math.seedrandom(seed);
+
+  var m = array.length, t, i;
+  while (m) {
+    i = Math.floor(Math.random() * m--);
+    t = array[m];
+    array[m] = array[i];
+    array[i] = t;
+  }
+}

--- a/public/review/index.html
+++ b/public/review/index.html
@@ -2,6 +2,9 @@
   <head>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <script src="/js/config.js"></script>
+    <!-- SeedRandom -->
+    <script src="//cdnjs.cloudflare.com/ajax/libs/seedrandom/3.0.1/seedrandom.min.js">
+    </script>
     <!-- Angular Material style sheet -->
     <link rel="stylesheet" href="https://ajax.googleapis.com/ajax/libs/angular_material/1.1.4/angular-material.min.css">
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">


### PR DESCRIPTION
Modify reviewer portal to shuffle entries list based on UID. This ensures each reviewer scores the sessions in a unique order, reducing ordering bias towards earlier submissions.